### PR TITLE
fix: Shabbos/Yom Tov has category Candles/Havdalah

### DIFF
--- a/src/jewcal/core.py
+++ b/src/jewcal/core.py
@@ -70,8 +70,8 @@ class JewCal:  # pylint: disable=too-many-instance-attributes
             - Shabbos or Yom Tov
             - category (Candles or Havdalah).
 
-        If the first day of Yom Tov starts on Shabbos, the category is set
-        to Candles instead of Havdalah.
+        If Shabbos / Yom Tov has Candles / Havdalah, Candles has priority. The category
+        is set to Candles instead of Havdalah.
 
         Args:
             gregorian_date: The Gregorian date.
@@ -101,9 +101,14 @@ class JewCal:  # pylint: disable=too-many-instance-attributes
         if self.month in holidays and self.day in holidays[self.month]:
             event = holidays[self.month][self.day]
             self.yomtov = event.title
+
+            # don't overwrite category `None` if Chol HaMoed is on Shabbos
             if event.category:
-                # don't overwrite category if chol hamoed is on shabbos
-                self.category = event.category
+                if not self.category:
+                    self.category = event.category
+                elif self.category != event.category:
+                    # if Shabbos / Yom Tov has Candles / Havdalah, Candles has priority
+                    self.category = 'Candles'
 
     def __str__(self) -> str:
         """Jewish date as a string.

--- a/tests/jewcal/test_core.py
+++ b/tests/jewcal/test_core.py
@@ -203,3 +203,31 @@ class JewCalTestCase(TestCase):
             + "shabbos='Shabbos', yomtov='Pesach 1', category='Havdalah', "
             + 'diaspora=False)',
         )
+
+    def test_category_adjusted(self) -> None:
+        """Test adjusted category."""
+        # Diaspora
+        erev_pesach = JewCal(date(2023, 4, 5))
+        self.assertEqual(erev_pesach.category, Category.CANDLES.value)
+
+        pesach_1 = JewCal(date(2023, 4, 6))
+        self.assertEqual(pesach_1.category, Category.CANDLES.value)
+
+        pesach_2 = JewCal(date(2023, 4, 7))
+        self.assertEqual(pesach_2.category, Category.CANDLES.value)
+
+        pesach_2 = JewCal(date(2023, 4, 8))
+        self.assertEqual(pesach_2.category, Category.HAVDALAH.value)
+
+        # Israel
+        erev_pesach = JewCal(date(2023, 4, 5), diaspora=False)
+        self.assertEqual(erev_pesach.category, Category.CANDLES.value)
+
+        pesach_1 = JewCal(date(2023, 4, 6), diaspora=False)
+        self.assertEqual(pesach_1.category, Category.HAVDALAH.value)
+
+        pesach_2 = JewCal(date(2023, 4, 7), diaspora=False)
+        self.assertEqual(pesach_2.category, Category.CANDLES.value)
+
+        pesach_2 = JewCal(date(2023, 4, 8), diaspora=False)
+        self.assertEqual(pesach_2.category, Category.HAVDALAH.value)


### PR DESCRIPTION
If Shabbos / Yom Tov has Candles / Havdalah, Candles has priority. 
The category is set to Candles instead of Havdalah.