### PR TITLE
fix: adar_2 

### DIFF
--- a/src/jewcal/constants.py
+++ b/src/jewcal/constants.py
@@ -1,5 +1,7 @@
 """Constants."""
 
+from __future__ import annotations
+
 from enum import Enum, IntEnum, unique
 from typing import Final, NamedTuple
 
@@ -13,7 +15,7 @@ class Category(Enum):
 
 
 @unique
-class Months(IntEnum):
+class Month(IntEnum):
     """The Jewish months."""
 
     TISHREI = 7
@@ -22,6 +24,7 @@ class Months(IntEnum):
     TEVET = 10
     SHEVAT = 11
     ADAR = 12
+    ADAR_1 = 14
     ADAR_2 = 13
     NISAN = 1
     IYAR = 2
@@ -29,6 +32,35 @@ class Months(IntEnum):
     TAMUZ = 4
     AV = 5
     ELUL = 6
+
+    def __str__(self) -> str:
+        """Get the month as a readable string.
+
+        Returns:
+            The month.
+        """
+        return self.name.capitalize().replace('_', ' ')
+
+    @classmethod
+    def get(cls, number: int, leap: bool) -> Month:
+        """Get the enum member.
+
+        Regarding the months Adar, Adar 1 and 2:
+        - If the Jewish year is non-leap, it returns Adar.
+        - If the Jewish year is leap, it returns Adar 1 or Adar 2.
+
+        Args:
+            number: The month number.
+            leap: Is the Jewish year a leap year.
+
+        Returns:
+            The enum member.
+        """
+        match number:
+            case 12:
+                return Month.ADAR_1 if leap else Month.ADAR
+            case _:
+                return Month(number)
 
 
 class Event(NamedTuple):

--- a/src/jewcal/core.py
+++ b/src/jewcal/core.py
@@ -25,13 +25,14 @@ shabbos=None, yomtov='Chol HaMoed 1 (Pesach 2)', category=None, is_erev=False,
 diaspora=False)
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 
-from .constants import SHABBOS, YOMTOV, YOMTOV_ISRAEL, Category, Months
+from .constants import SHABBOS, YOMTOV, YOMTOV_ISRAEL, Category, Month
 from .utils.calculations import (
     absdate_to_jewish,
     gregorian_to_absdate,
+    is_jewish_leap,
     weekday_from_absdate,
 )
 
@@ -48,6 +49,9 @@ class JewCal:  # pylint: disable=too-many-instance-attributes
 
     day: int
     """The day of the Jewish month."""
+
+    _is_leap: bool = field(repr=False)
+    """Is it a Jewish leap year."""
 
     gregorian_date: date
     """The date in the Gregorian calendar."""
@@ -91,6 +95,7 @@ class JewCal:  # pylint: disable=too-many-instance-attributes
             gregorian_date.year, gregorian_date.month, gregorian_date.day
         )
         self.year, self.month, self.day = absdate_to_jewish(absdate)
+        self._is_leap = is_jewish_leap(self.year)
 
         # gregorian date
         self.gregorian_date = gregorian_date
@@ -131,7 +136,11 @@ class JewCal:  # pylint: disable=too-many-instance-attributes
         Returns:
             The Jewish date.
         """
-        return f'{self.day} {Months(self.month).name.capitalize()} {self.year}'
+        return (
+            f'{self.day}'
+            f' {Month.get(self.month, self._is_leap)}'  # Adar 1/2 in leap year
+            f' {self.year}'
+        )
 
     def _erev(self) -> None:
         is_erev_shabbos = self.shabbos and 'Erev' in self.shabbos

--- a/src/jewcal/utils/calculations.py
+++ b/src/jewcal/utils/calculations.py
@@ -12,7 +12,7 @@ https://www.david-greve.de/luach-code/jewish-python.html
 from calendar import isleap, monthrange
 from datetime import date
 
-from jewcal.constants import Month
+from ..constants import Month
 
 # Calculated date of the world's creation, is equivalent to sunset on the Julian
 # proleptic calendar date 6 October 3761 BCE

--- a/src/jewcal/utils/calculations.py
+++ b/src/jewcal/utils/calculations.py
@@ -12,7 +12,7 @@ https://www.david-greve.de/luach-code/jewish-python.html
 from calendar import isleap, monthrange
 from datetime import date
 
-from jewcal.constants import Months
+from jewcal.constants import Month
 
 # Calculated date of the world's creation, is equivalent to sunset on the Julian
 # proleptic calendar date 6 October 3761 BCE
@@ -154,16 +154,16 @@ def jewish_to_absdate(year: int, month: int, day: int) -> int:
     return_value = value
 
     # If before Tishrei
-    if month < Months.TISHREI:
+    if month < Month.TISHREI:
         # add days in prior months this year before and after Nisan.
-        for i in range(Months.TISHREI, months_in_jewish_year(year) + 1):
+        for i in range(Month.TISHREI, months_in_jewish_year(year) + 1):
             value = days_in_jewish_month(year, i)
             return_value += value
         for i in range(1, month):
             value = days_in_jewish_month(year, i)
             return_value += value
     else:
-        for i in range(Months.TISHREI, month):
+        for i in range(Month.TISHREI, month):
             value = days_in_jewish_month(year, i)
             return_value += value
 

--- a/tests/jewcal/test_core.py
+++ b/tests/jewcal/test_core.py
@@ -180,8 +180,25 @@ class JewCalTestCase(TestCase):
 
     def test_jewcal_to_string(self) -> None:
         """Test `JewCal`-object to `str`."""
+        # non-leap Jewish year
+        jewcal = JewCal(date(2023, 3, 15))
+        self.assertEqual(str(jewcal), '22 Adar 5783')
+
+        # leap Jewish year
         jewcal = JewCal(date(2022, 4, 16))
         self.assertEqual(str(jewcal), '15 Nisan 5782')
+
+        jewcal = JewCal(date(2022, 2, 27))
+        self.assertEqual(str(jewcal), '26 Adar 1 5782')
+
+        jewcal = JewCal(date(2022, 3, 16))
+        self.assertEqual(str(jewcal), '13 Adar 2 5782')
+
+        jewcal = JewCal(date(2024, 2, 10))
+        self.assertEqual(str(jewcal), '1 Adar 1 5784')
+
+        jewcal = JewCal(date(2024, 3, 11))
+        self.assertEqual(str(jewcal), '1 Adar 2 5784')
 
     def test_jewcal_to_repr(self) -> None:
         """Test `JewCal`-object to `repr`."""


### PR DESCRIPTION
If it is a Jewish leap year, Adar should be Adar 1 or Adar 2.
