### PR TITLE
refactor: Set attributes in Events.__post_init__

### DIFF
--- a/tests/jewcal/models/test_events.py
+++ b/tests/jewcal/models/test_events.py
@@ -2,8 +2,7 @@
 
 from unittest import TestCase
 
-from jewcal.constants import SHABBOS, YOMTOV, YOMTOV_ISRAEL
-
+from src.jewcal.constants import SHABBOS, YOMTOV, YOMTOV_ISRAEL, Action
 from src.jewcal.models.events import Events
 
 # ruff: noqa: SLF001
@@ -13,298 +12,451 @@ from src.jewcal.models.events import Events
 class EventsTestCase(TestCase):
     """Unittests for Events."""
 
-    def setUp(self) -> None:
-        """Initialize."""
-        self.events = Events()
+    def test_attr_yomtov(self) -> None:
+        """It is a Yom Tov with a different action if Diaspora / Israel."""
+        # Diaspora
+        # 2022, 4, 16
+        shabbos_pesach_1 = Events(6, 1, 15, diaspora=True)
+        self.assertEqual(shabbos_pesach_1.shabbos, SHABBOS[6].title)
+        self.assertEqual(shabbos_pesach_1.yomtov, YOMTOV[1][15].title)
+        self.assertEqual(shabbos_pesach_1.action, Action.CANDLES.value)
 
-    def tearDown(self) -> None:
-        """Clean up after tests."""
-        self.events = Events()
+        # 2022, 4, 17
+        pesach_2 = Events(0, 1, 16, diaspora=True)
+        self.assertIsNone(pesach_2.shabbos)
+        self.assertEqual(pesach_2.yomtov, YOMTOV[1][16].title)
+        self.assertEqual(pesach_2.action, Action.HAVDALAH.value)
+
+        # Israel
+        # 2022, 4, 16
+        shabbos_pesach_1 = Events(6, 1, 15, diaspora=False)
+        self.assertEqual(shabbos_pesach_1.shabbos, SHABBOS[6].title)
+        self.assertEqual(shabbos_pesach_1.yomtov, YOMTOV_ISRAEL[1][15].title)
+        self.assertEqual(shabbos_pesach_1.action, Action.HAVDALAH.value)
+
+        # 2022, 4, 17
+        ch_h_pesach_2 = Events(0, 1, 16, diaspora=False)
+        self.assertIsNone(ch_h_pesach_2.shabbos)
+        self.assertEqual(ch_h_pesach_2.yomtov, YOMTOV_ISRAEL[1][16].title)
+        self.assertIsNone(ch_h_pesach_2.action)
+
+    def test_attr_erev_shabbos(self) -> None:
+        """It is Erev Shabbos with candles as action."""
+        # 2024-06-21
+
+        # Diaspora
+        erev_shabbos = Events(5, 3, 15, diaspora=True)
+        self.assertEqual(erev_shabbos.shabbos, SHABBOS[5].title)
+        self.assertEqual(erev_shabbos.action, Action.CANDLES.value)
+        self.assertIsNone(erev_shabbos.yomtov)
+
+        # Israel
+        erev_shabbos = Events(5, 3, 15, diaspora=False)
+        self.assertEqual(erev_shabbos.shabbos, SHABBOS[5].title)
+        self.assertEqual(erev_shabbos.action, Action.CANDLES.value)
+        self.assertIsNone(erev_shabbos.yomtov)
+
+    def test_attr_shabbos(self) -> None:
+        """It is Shabbos with havdalah as action."""
+        # 2024-06-22
+
+        # Diaspora
+        shabbos = Events(6, 3, 16, diaspora=True)
+        self.assertEqual(shabbos.shabbos, SHABBOS[6].title)
+        self.assertEqual(shabbos.action, Action.HAVDALAH.value)
+        self.assertIsNone(shabbos.yomtov)
+
+        # Israel
+        shabbos = Events(6, 3, 16, diaspora=False)
+        self.assertEqual(shabbos.shabbos, SHABBOS[6].title)
+        self.assertEqual(shabbos.action, Action.HAVDALAH.value)
+        self.assertIsNone(shabbos.yomtov)
+
+    def test_attr_shabbos_chol_hamoed_sukkos(self) -> None:
+        """It is Shabbos Chol Hamoed Sukkos with havdalah as action."""
+        # 2021, 9, 25
+
+        # Diaspora
+        shabbos_ch_h_sukkos = Events(6, 7, 19, diaspora=True)
+        self.assertEqual(shabbos_ch_h_sukkos.shabbos, SHABBOS[6].title)
+        self.assertEqual(shabbos_ch_h_sukkos.action, Action.HAVDALAH.value)
+        self.assertEqual(shabbos_ch_h_sukkos.yomtov, YOMTOV[7][19].title)
+
+        # Israel
+        shabbos_ch_h_sukkos = Events(6, 7, 19, diaspora=False)
+        self.assertEqual(shabbos_ch_h_sukkos.shabbos, SHABBOS[6].title)
+        self.assertEqual(shabbos_ch_h_sukkos.action, Action.HAVDALAH.value)
+        self.assertEqual(shabbos_ch_h_sukkos.yomtov, YOMTOV_ISRAEL[7][19].title)
+
+    def test_attr_shabbos_chol_hamoed_pesach(self) -> None:
+        """It is Shabbos Chol Hamoed Pesach with havdalah as action."""
+        # 2020, 4, 11
+
+        # Diaspora
+        shabbos_ch_h_pesach = Events(6, 1, 17, diaspora=True)
+        self.assertEqual(shabbos_ch_h_pesach.shabbos, SHABBOS[6].title)
+        self.assertEqual(shabbos_ch_h_pesach.action, Action.HAVDALAH.value)
+        self.assertEqual(shabbos_ch_h_pesach.yomtov, YOMTOV[1][17].title)
+
+        # Israel
+        shabbos_ch_h_pesach = Events(6, 1, 17, diaspora=False)
+        self.assertEqual(shabbos_ch_h_pesach.shabbos, SHABBOS[6].title)
+        self.assertEqual(shabbos_ch_h_pesach.action, Action.HAVDALAH.value)
+        self.assertEqual(shabbos_ch_h_pesach.yomtov, YOMTOV_ISRAEL[1][17].title)
+
+    def test_action_adjusted(self) -> None:
+        """Test adjusted action."""
+        # Diaspora
+        # 2023
+        erev_pesach = Events(3, 1, 14, diaspora=True)  # 2023, 4, 5
+        self.assertEqual(erev_pesach.action, Action.CANDLES.value)
+
+        pesach_1 = Events(4, 1, 15, diaspora=True)  # 2023, 4, 6
+        self.assertEqual(pesach_1.action, Action.CANDLES.value)
+
+        pesach_2 = Events(5, 1, 16, diaspora=True)  # 2023, 4, 7
+        self.assertEqual(pesach_2.action, Action.CANDLES.value)
+
+        chol_hamoed_1 = Events(6, 1, 17, diaspora=True)  # 2023, 4, 8
+        self.assertEqual(chol_hamoed_1.action, Action.HAVDALAH.value)
+
+        # 2024
+        chol_hamoed_2 = Events(5, 1, 18, diaspora=True)  # 2024, 4, 26
+        self.assertEqual(chol_hamoed_2.action, Action.CANDLES.value)
+
+        chol_hamoed_3 = Events(6, 1, 19, diaspora=True)  # 2024, 4, 27
+        self.assertEqual(chol_hamoed_3.action, Action.HAVDALAH.value)
+
+        # Israel
+        # 2023
+        erev_pesach = Events(3, 1, 14, diaspora=False)  # 2023, 4, 5
+        self.assertEqual(erev_pesach.action, Action.CANDLES.value)
+
+        pesach_1 = Events(4, 1, 15, diaspora=False)  # 2023, 4, 6
+        self.assertEqual(pesach_1.action, Action.HAVDALAH.value)
+
+        chol_hamoed_1 = Events(5, 1, 16, diaspora=False)  # 2023, 4, 7
+        self.assertEqual(chol_hamoed_1.action, Action.CANDLES.value)
+
+        chol_hamoed_2 = Events(6, 1, 17, diaspora=False)  # 2023, 4, 8
+        self.assertEqual(chol_hamoed_2.action, Action.HAVDALAH.value)
+
+        # 2024
+        chol_hamoed_3 = Events(5, 1, 18, diaspora=False)  # 2024, 4, 26
+        self.assertEqual(chol_hamoed_3.action, Action.CANDLES.value)
+
+        chol_hamoed_4 = Events(6, 1, 19, diaspora=False)  # 2024, 4, 27
+        self.assertEqual(chol_hamoed_4.action, Action.HAVDALAH.value)
 
     def test_events_to_string(self) -> None:
         """Test `Events`-object to `str`."""
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = YOMTOV[1][15].title
-        self.events.action = YOMTOV[1][15].action
-        self.assertEqual(str(self.events), 'Shabbos, Pesach 1')
+        # 2022, 4, 16 Shabbos, Pesach 1
+        events = Events(6, 1, 15, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertEqual(events.yomtov, YOMTOV[1][15].title)
+        self.assertEqual(events.action, YOMTOV[1][15].action)
+        self.assertEqual(str(events), 'Shabbos, Pesach 1')
 
     def test_no_events_to_string(self) -> None:
         """Test no `Events`-object to `str`."""
-        self.assertEqual(str(Events()), '')
+        self.assertEqual(str(Events(4, 3, 14, diaspora=True)), '')
 
     def test_has_events(self) -> None:
         """Test events."""
-        self.events.shabbos = SHABBOS[6].title  # Shabbos
-        self.events.yomtov = YOMTOV[1][15].title  # Pesach 1
-        self.events.action = YOMTOV[1][15].action
-        self.assertTrue(self.events._has_events())
+        # 2022, 4, 16 Shabbos, Pesach 1
+        events = Events(6, 1, 15, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertEqual(events.yomtov, YOMTOV[1][15].title)
+        self.assertEqual(events.action, YOMTOV[1][15].action)
+        self.assertTrue(events._has_events())
 
     def test_has_no_events(self) -> None:
         """Test no events."""
-        self.assertFalse(Events()._has_events())
+        self.assertFalse(Events(4, 3, 14, diaspora=True)._has_events())
 
     def test_is_erev_shabbos_and_not_is_shabbos(self) -> None:
         """Test Erev Shabbos."""
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = None
-        self.events.action = SHABBOS[5].action
-        self.assertTrue(self.events._is_erev_shabbos())
-        self.assertFalse(self.events._is_shabbos())
+        events = Events(5, 3, 15, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[5].title)
+        self.assertIsNone(events.yomtov)
+        self.assertEqual(events.action, SHABBOS[5].action)
+        self.assertTrue(events._is_erev_shabbos())
+        self.assertFalse(events._is_shabbos())
 
     def test_is_not_erev_shabbos_and_is_shabbos(self) -> None:
         """Test it is Shabbos."""
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = None
-        self.events.action = SHABBOS[6].action
-        self.assertFalse(self.events._is_erev_shabbos())
-        self.assertTrue(self.events._is_shabbos())
+        events = Events(6, 3, 16, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertIsNone(events.yomtov)
+        self.assertEqual(events.action, SHABBOS[6].action)
+        self.assertFalse(events._is_erev_shabbos())
+        self.assertTrue(events._is_shabbos())
 
     def test_is_not_erev_shabbos_and_not_is_shabbos(self) -> None:
         """Test it is not (Erev) Shabbos."""
-        self.events.shabbos = None
-        self.events.yomtov = None
-        self.events.action = None
-        self.assertFalse(self.events._is_erev_shabbos())
-        self.assertFalse(self.events._is_shabbos())
+        events = Events(4, 3, 14, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertIsNone(events.yomtov)
+        self.assertIsNone(events.action)
+        self.assertFalse(events._is_erev_shabbos())
+        self.assertFalse(events._is_shabbos())
 
     def test_is_erev_yomtov_and_not_is_yomtov(self) -> None:
         """Test Erev Yom Tov."""
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[6][29].title  # Erev Rosh Hashana
-        self.events.action = YOMTOV[6][29].action
-        self.assertTrue(self.events._is_erev_yomtov())
-        self.assertFalse(self.events._is_yomtov())
+        # 2024-09-02 Erev Rosh Hashana
+        events = Events(3, 6, 29, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[6][29].title)
+        self.assertEqual(events.action, YOMTOV[6][29].action)
+        self.assertTrue(events._is_erev_yomtov())
+        self.assertFalse(events._is_yomtov())
 
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[7][21].title  # Hoshana Rabba (Sukkos 7)
-        self.events.action = YOMTOV[7][21].action
-        self.assertTrue(self.events._is_erev_yomtov())
-        self.assertFalse(self.events._is_yomtov())
+        # 2024-10-23 Hoshana Rabba (Sukkos 7)
+        events = Events(3, 7, 21, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[7][21].title)
+        self.assertEqual(events.action, YOMTOV[7][21].action)
+        self.assertTrue(events._is_erev_yomtov())
+        self.assertFalse(events._is_yomtov())
 
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[7][21].title  # Hoshana Rabba (Sukkot 7)
-        self.events.action = YOMTOV_ISRAEL[7][21].action
-        self.assertTrue(self.events._is_erev_yomtov())
-        self.assertFalse(self.events._is_yomtov())
+        # 2024-10-23 Hoshana Rabba (Sukkot 7)
+        events = Events(3, 7, 21, diaspora=False)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[7][21].title)
+        self.assertEqual(events.action, YOMTOV_ISRAEL[7][21].action)
+        self.assertTrue(events._is_erev_yomtov())
+        self.assertFalse(events._is_yomtov())
 
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[1][20].title  # Chol HaMoed 4 (Pesach 6)
-        self.events.action = YOMTOV[1][20].action
-        self.assertTrue(self.events._is_erev_yomtov())
-        self.assertFalse(self.events._is_yomtov())
+        # 2024-04-28 Chol HaMoed 4 (Pesach 6)
+        events = Events(3, 1, 20, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[1][20].title)
+        self.assertEqual(events.action, YOMTOV[1][20].action)
+        self.assertTrue(events._is_erev_yomtov())
+        self.assertFalse(events._is_yomtov())
 
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[1][20].title  # Chol HaMoed 5 (Pesach 6)
-        self.events.action = YOMTOV_ISRAEL[1][20].action
-        self.assertTrue(self.events._is_erev_yomtov())
-        self.assertFalse(self.events._is_yomtov())
+        # Chol HaMoed 5 (Pesach 6)
+        events = Events(3, 1, 20, diaspora=False)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[1][20].title)
+        self.assertEqual(events.action, YOMTOV_ISRAEL[1][20].action)
+        self.assertTrue(events._is_erev_yomtov())
+        self.assertFalse(events._is_yomtov())
 
     def test_is_not_erev_yomtov_and_is_yomtov(self) -> None:
         """Test it is Yom Tov."""
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[7][1].title  # Rosh Hashana 1
-        self.events.action = YOMTOV[7][1].action
-        self.assertFalse(self.events._is_erev_yomtov())
-        self.assertTrue(self.events._is_yomtov())
+        # 2024-09-03 Rosh Hashana 1
+        events = Events(4, 7, 1, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[7][1].title)
+        self.assertEqual(events.action, YOMTOV[7][1].action)
+        self.assertFalse(events._is_erev_yomtov())
+        self.assertTrue(events._is_yomtov())
 
     def test_is_not_erev_yomtov_and_not_is_yomtov(self) -> None:
         """Test it is not (Erev) Yom Tov."""
-        self.events.shabbos = None
-        self.events.yomtov = None
-        self.events.action = None
-        self.assertFalse(self.events._is_erev_yomtov())
-        self.assertFalse(self.events._is_yomtov())
+        # 2024-06-21
+        events = Events(4, 3, 14, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertIsNone(events.yomtov)
+        self.assertIsNone(events.action)
+        self.assertFalse(events._is_erev_yomtov())
+        self.assertFalse(events._is_yomtov())
 
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[7][17].title  # Chol HaMoed 1 (Sukkos 3)
-        self.events.action = None
-        self.assertFalse(self.events._is_erev_yomtov())
-        self.assertFalse(self.events._is_yomtov())
+        # 2024-04-25 Chol HaMoed 1 (Sukkos 3)
+        events = Events(4, 7, 17, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[7][17].title)
+        self.assertIsNone(events.action)
+        self.assertFalse(events._is_erev_yomtov())
+        self.assertFalse(events._is_yomtov())
 
     def test_is_erev(self) -> None:
         """Test it is Erev Shabbos and/or Erev Yom Tov."""
         # Diaspora
-        # 2023, 9, 15
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = YOMTOV[6][29].title  # Erev Rosh Hashana
-        self.events.action = YOMTOV[6][29].action
-        self.assertTrue(self.events._is_erev())
+        # 2023, 9, 15  Erev Rosh Hashana
+        events = Events(5, 6, 29, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[5].title)
+        self.assertEqual(events.yomtov, YOMTOV[6][29].title)
+        self.assertEqual(events.action, YOMTOV[6][29].action)
+        self.assertTrue(events._is_erev())
 
-        # 2024, 4, 22
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[1][14].title  # Erev Pesach
-        self.events.action = YOMTOV[1][14].action
-        self.assertTrue(self.events._is_erev())
+        # 2024, 4, 22 Erev Pesach
+        events = Events(1, 1, 14, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[1][14].title)
+        self.assertEqual(events.action, YOMTOV[1][14].action)
+        self.assertTrue(events._is_erev())
 
-        # 2024, 4, 26
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = YOMTOV[1][18].title  # Chol HaMoed 2 (Pesach 4)
-        self.events.action = 'Candles'  # adjusted through JewCal initialization
-        self.assertTrue(self.events._is_erev())
+        # 2024, 4, 26  Chol HaMoed 2 (Pesach 4)
+        events = Events(5, 1, 18, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[5].title)
+        self.assertEqual(events.yomtov, YOMTOV[1][18].title)
+        self.assertEqual(events.action, Action.CANDLES.value)
+        self.assertTrue(events._is_erev())
 
         # Israel
         # 2023, 9, 22
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = None
-        self.events.action = SHABBOS[5].action
-        self.assertTrue(self.events._is_erev())
+        events = Events(5, 7, 7, diaspora=False)
+        self.assertEqual(events.shabbos, SHABBOS[5].title)
+        self.assertIsNone(events.yomtov)
+        self.assertEqual(events.action, SHABBOS[5].action)
+        self.assertTrue(events._is_erev())
 
-        # 2024, 4, 22
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[1][14].title  # Erev Pesach
-        self.events.action = YOMTOV_ISRAEL[1][14].action
-        self.assertTrue(self.events._is_erev())
+        # 2024, 4, 26 Chol HaMoed 3 (Pesach 4)
+        events = Events(5, 1, 18, diaspora=False)
+        self.assertEqual(events.shabbos, SHABBOS[5].title)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[1][18].title)
+        self.assertEqual(events.action, Action.CANDLES.value)
+        self.assertTrue(events._is_erev())
 
-        # 2024, 4, 26
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = YOMTOV_ISRAEL[1][18].title  # Chol HaMoed 3 (Pesach 4)
-        self.events.action = 'Candles'  # adjusted through JewCal initialization
-        self.assertTrue(self.events._is_erev())
-
-        # 2024, 10, 2
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[6][29].title  # Erev Rosh Hashana
-        self.events.action = YOMTOV_ISRAEL[6][29].action
-        self.assertTrue(self.events._is_erev())
+        # 2024, 10, 2 Erev Rosh Hashana
+        events = Events(3, 6, 29, diaspora=False)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[6][29].title)
+        self.assertEqual(events.action, YOMTOV_ISRAEL[6][29].action)
+        self.assertTrue(events._is_erev())
 
     def test_is_not_erev(self) -> None:
         """Test it is not Erev Shabbos and/or Erev Yom Tov."""
         # Diaspora
-        # 2023, 9, 16
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = YOMTOV[7][1].title  # Rosh Hashana 1
-        self.events.action = YOMTOV[7][1].action
-        self.assertFalse(self.events._is_erev())
+        # 2023, 9, 16 Rosh Hashana 1
+        events = Events(6, 7, 1, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertEqual(events.yomtov, YOMTOV[7][1].title)
+        self.assertEqual(events.action, YOMTOV[7][1].action)
+        self.assertFalse(events._is_erev())
 
-        # 2023, 9, 17
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[7][2].title  # Rosh Hashana 2
-        self.events.action = YOMTOV[7][2].action
-        self.assertFalse(self.events._is_erev())
+        # 2023, 9, 17 Rosh Hashana 2
+        events = Events(0, 7, 2, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[7][2].title)
+        self.assertEqual(events.action, YOMTOV[7][2].action)
+        self.assertFalse(events._is_erev())
 
-        # 2024, 4, 25
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[1][17].title  # Chol HaMoed 1 (Pesach 3)'
-        self.events.action = None
-        self.assertFalse(self.events._is_erev())
+        # 2024, 4, 25 Chol HaMoed 1 (Pesach 3)
+        events = Events(4, 1, 17, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[1][17].title)
+        self.assertIsNone(events.action)
+        self.assertFalse(events._is_erev())
 
-        # 2024, 4, 27
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = YOMTOV[1][19].title  # Chol HaMoed 3 (Pesach 5)'
-        self.events.action = YOMTOV[1][19].action
-        self.assertFalse(self.events._is_erev())
-
-        # 2024, 10, 3
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[7][1].title  # Rosh Hashana 1
-        self.events.action = YOMTOV[7][1].action
-        self.assertFalse(self.events._is_erev())
-
-        # 2024, 10, 4
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = YOMTOV[7][2].title  # Rosh Hashana 2
-        self.events.action = YOMTOV[7][2].action
-        self.assertFalse(self.events._is_erev())
-
-        # 2024, 10, 5
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = None
-        self.events.action = SHABBOS[6].action
-        self.assertFalse(self.events._is_erev())
+        # 2024, 4, 27 Chol HaMoed 3 (Pesach 5)
+        events = Events(6, 1, 19, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertEqual(events.yomtov, YOMTOV[1][19].title)
+        self.assertEqual(events.action, Action.HAVDALAH.value)
+        self.assertFalse(events._is_erev())
 
         # Israel
-        # 2024, 4, 23
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[1][15].title
-        self.events.action = YOMTOV_ISRAEL[1][15].action
-        self.assertFalse(self.events._is_erev())
+        # 2024, 4, 23 Pesach 1
+        events = Events(2, 1, 15, diaspora=False)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[1][15].title)
+        self.assertEqual(events.action, YOMTOV_ISRAEL[1][15].action)
+        self.assertFalse(events._is_erev())
 
-        # 2024, 4, 24
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[1][16].title  # Chol HaMoed 1 (Pesach 2)
-        self.events.action = None
-        self.assertFalse(self.events._is_erev())
+        # 2024, 4, 24 Chol HaMoed 1 (Pesach 2)
+        events = Events(3, 1, 16, diaspora=False)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[1][16].title)
+        self.assertIsNone(events.action)
+        self.assertFalse(events._is_erev())
 
-        # 2024, 4, 27
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = YOMTOV_ISRAEL[1][19].title  # Chol HaMoed 4 (Pesach 5)
-        self.events.action = YOMTOV_ISRAEL[1][19].action
-        self.assertFalse(self.events._is_erev())
+        # 2024, 4, 27 Chol HaMoed 4 (Pesach 5)
+        events = Events(6, 1, 19, diaspora=False)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[1][19].title)
+        self.assertEqual(events.action, Action.HAVDALAH.value)
+        self.assertFalse(events._is_erev())
 
-        # 2024, 10, 3
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[7][1].title  # Rosh Hashana 1
-        self.events.action = YOMTOV_ISRAEL[7][1].action
-        self.assertFalse(self.events._is_erev())
+        # 2024, 10, 3 Rosh Hashana 1
+        events = Events(4, 7, 1, diaspora=False)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[7][1].title)
+        self.assertEqual(events.action, YOMTOV_ISRAEL[7][1].action)
+        self.assertFalse(events._is_erev())
 
-        # 2024, 10, 4
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = YOMTOV_ISRAEL[7][2].title  # Rosh Hashana 2
-        self.events.action = YOMTOV_ISRAEL[7][2].action
-        self.assertFalse(self.events._is_erev())
+        # 2024, 10, 4 Rosh Hashana 2
+        events = Events(5, 7, 2, diaspora=False)
+        self.assertEqual(events.shabbos, SHABBOS[5].title)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[7][2].title)
+        self.assertEqual(events.action, Action.CANDLES.value)
+        self.assertFalse(events._is_erev())
 
     def test_is_issur_melacha(self) -> None:
         """Test it is Issur melacha."""
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = None
-        self.events.action = SHABBOS[6].action
-        self.assertTrue(self.events._is_issur_melacha())
-
         # Diaspora
-        # 2023, 4, 6
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[1][15].title
-        self.events.action = YOMTOV[1][15].action
-        self.assertTrue(self.events._is_issur_melacha())
+        # 2024-06-22
+        events = Events(6, 3, 16, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertIsNone(events.yomtov)
+        self.assertEqual(events.action, SHABBOS[6].action)
+        self.assertTrue(events._is_issur_melacha())
 
-        # 2023, 4, 7
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = YOMTOV[1][16].title  # Pesach 2
-        self.events.action = YOMTOV[1][16].action
-        self.assertTrue(self.events._is_issur_melacha())
+        # 2023, 4, 6 Pesach 1
+        events = Events(4, 1, 15, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[1][15].title)
+        self.assertEqual(events.action, YOMTOV[1][15].action)
+        self.assertTrue(events._is_issur_melacha())
 
-        # 2023, 4, 8
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = YOMTOV[1][17].title  # Chol HaMoed 1 (Pesach 3)
-        self.events.action = 'Hadalah'  # adjusted through JewCal initialization
-        self.assertTrue(self.events._is_issur_melacha())
+        # 2023, 4, 7 Pesach 2
+        events = Events(5, 1, 16, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[5].title)
+        self.assertEqual(events.yomtov, YOMTOV[1][16].title)
+        self.assertEqual(events.action, Action.CANDLES.value)
+        self.assertTrue(events._is_issur_melacha())
+
+        # 2023, 4, 8 Chol HaMoed 1 (Pesach 3)
+        events = Events(6, 1, 17, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertEqual(events.yomtov, YOMTOV[1][17].title)
+        self.assertEqual(events.action, Action.HAVDALAH.value)
+        self.assertTrue(events._is_issur_melacha())
 
         # Israel
-        # 2023, 4, 6
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[1][15].title  # Pesach 1
-        self.events.action = YOMTOV_ISRAEL[1][15].action
-        self.assertTrue(self.events._is_issur_melacha())
+        # 2023, 4, 6 Pesach 1
+        events = Events(4, 1, 15, diaspora=False)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[1][15].title)
+        self.assertEqual(events.action, YOMTOV_ISRAEL[1][15].action)
+        self.assertTrue(events._is_issur_melacha())
 
-        # 2023, 4, 8
-        self.events.shabbos = SHABBOS[6].title
-        self.events.yomtov = YOMTOV_ISRAEL[1][17].title  # Chol HaMoed 1 (Pesach 3)
-        self.events.action = 'Hadalah'  # adjusted through JewCal initialization
-        self.assertTrue(self.events._is_issur_melacha())
+        # 2023, 4, 8 Chol HaMoed 1 (Pesach 3)
+        events = Events(6, 1, 17, diaspora=False)
+        self.assertEqual(events.shabbos, SHABBOS[6].title)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[1][17].title)
+        self.assertEqual(events.action, Action.HAVDALAH.value)
+        self.assertTrue(events._is_issur_melacha())
 
     def test_is_not_issur_melacha(self) -> None:
         """Test it is not Issur melacha."""
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = None
-        self.events.action = SHABBOS[5].action
-        self.assertFalse(self.events._is_issur_melacha())
-
         # Diaspora
-        # 2023, 4, 5
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV[1][14].title  # Erev Pesach
-        self.events.action = YOMTOV[1][14].action
-        self.assertFalse(self.events._is_issur_melacha())
+        events = Events(5, 3, 15, diaspora=True)
+        self.assertEqual(events.shabbos, SHABBOS[5].title)
+        self.assertIsNone(events.yomtov)
+        self.assertEqual(events.action, SHABBOS[5].action)
+        self.assertFalse(events._is_issur_melacha())
+
+        # 2023, 4, 5 Erev Pesach
+        events = Events(3, 1, 14, diaspora=True)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV[1][14].title)
+        self.assertEqual(events.action, YOMTOV[1][14].action)
+        self.assertFalse(events._is_issur_melacha())
 
         # Israel
-        # 2023, 4, 5
-        self.events.shabbos = None
-        self.events.yomtov = YOMTOV_ISRAEL[1][14].title  # Erev Pesach
-        self.events.action = YOMTOV_ISRAEL[1][14].action
-        self.assertFalse(self.events._is_issur_melacha())
+        # 2023, 4, 5  YOMTOV_ISRAEL[1][14].title)
+        events = Events(3, 1, 14, diaspora=False)
+        self.assertIsNone(events.shabbos)
+        self.assertEqual(events.yomtov, YOMTOV_ISRAEL[1][14].title)
+        self.assertEqual(events.action, YOMTOV_ISRAEL[1][14].action)
+        self.assertFalse(events._is_issur_melacha())
 
-        # 2023, 4, 7
-        self.events.shabbos = SHABBOS[5].title
-        self.events.yomtov = YOMTOV_ISRAEL[1][16].title  # Chol HaMoed 1 (Pesach 2)
-        self.events.action = YOMTOV_ISRAEL[1][16].action
-        self.assertFalse(self.events._is_issur_melacha())
+        # 2023, 4, 7 Chol HaMoed 1 (Pesach 2)
+        events = Events(5, 1, 16, diaspora=False)
+        self.assertTrue(events.shabbos, SHABBOS[5].title)
+        self.assertTrue(events.yomtov, YOMTOV_ISRAEL[1][16].title)
+        self.assertTrue(events.action, YOMTOV_ISRAEL[1][16].action)
+        self.assertFalse(events._is_issur_melacha())

--- a/tests/jewcal/test_core.py
+++ b/tests/jewcal/test_core.py
@@ -7,10 +7,8 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from src.jewcal import JewCal
-from src.jewcal.constants import SHABBOS, YOMTOV, YOMTOV_ISRAEL, Action
+from src.jewcal.constants import SHABBOS, Action
 from src.jewcal.models.zmanim import Location
-
-# pylint: disable=too-many-public-methods
 
 
 @no_type_check
@@ -68,138 +66,6 @@ class JewCalTestCase(TestCase):
         self.assertIsNone(jewcal.events.yomtov)
         self.assertIsNone(jewcal.events.action)
 
-    def test_yomtov_candles(self) -> None:
-        """It is a Yom Tov with a different action if Diaspora / Israel."""
-        gregorian_date = date(2022, 4, 16)
-
-        # Diaspora
-        jewcal = JewCal(gregorian_date)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[6].title)  # Shabbos
-        self.assertEqual(jewcal.events.yomtov, YOMTOV[1][15].title)  # Pesach 1
-        self.assertEqual(jewcal.events.action, Action.CANDLES.value)
-
-        # Israel
-        jewcal = JewCal(gregorian_date, diaspora=False)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[6].title)  # Shabbos
-        self.assertEqual(jewcal.events.yomtov, YOMTOV_ISRAEL[1][15].title)  # Pesach 1
-        self.assertEqual(jewcal.events.action, Action.HAVDALAH.value)
-
-    def test_yomtov_havdalah(self) -> None:
-        """It is a Yom Tov in Diaspora, Chol HaMoed in Israel."""
-        gregorian_date = date(2022, 4, 17)
-
-        # Diaspora
-        jewcal = JewCal(gregorian_date)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertIsNone(jewcal.events.shabbos)
-        self.assertEqual(jewcal.events.yomtov, YOMTOV[1][16].title)  # Pesach 2
-        self.assertEqual(jewcal.events.action, Action.HAVDALAH.value)
-
-        # Israel
-        jewcal = JewCal(gregorian_date, diaspora=False)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertIsNone(jewcal.events.shabbos)
-        self.assertEqual(jewcal.events.yomtov, YOMTOV_ISRAEL[1][16].title)  # Ch"h 1
-        self.assertIsNone(jewcal.events.action)
-
-    def test_erev_shabbos(self) -> None:
-        """It is Erev Shabbos with candles as action."""
-        gregorian_date = date(2022, 8, 19)
-
-        # Diaspora
-        jewcal = JewCal(gregorian_date)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[5].title)  # Erev Shabbos
-        self.assertEqual(jewcal.events.action, Action.CANDLES.value)
-        self.assertIsNone(jewcal.events.yomtov)
-
-        # Israel
-        jewcal = JewCal(gregorian_date, diaspora=False)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[5].title)  # Erev Shabbos
-        self.assertEqual(jewcal.events.action, Action.CANDLES.value)
-        self.assertIsNone(jewcal.events.yomtov)
-
-    def test_shabbos(self) -> None:
-        """It is Shabbos with havdalah as action."""
-        gregorian_date = date(2022, 8, 20)
-
-        # Diaspora
-        jewcal = JewCal(gregorian_date)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[6].title)  # Shabbos
-        self.assertEqual(jewcal.events.action, Action.HAVDALAH.value)
-        self.assertIsNone(jewcal.events.yomtov)
-
-        # Israel
-        jewcal = JewCal(gregorian_date, diaspora=False)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[6].title)  # Shabbos
-        self.assertEqual(jewcal.events.action, Action.HAVDALAH.value)
-        self.assertIsNone(jewcal.events.yomtov)
-
-    def test_shabbos_chol_hamoed_sukkos(self) -> None:
-        """It is Shabbos Chol Hamoed Sukkos with havdalah as action."""
-        gregorian_date = date(2021, 9, 25)
-
-        # Diaspora
-        jewcal = JewCal(gregorian_date)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[6].title)  # Shabbos
-        self.assertEqual(jewcal.events.action, Action.HAVDALAH.value)
-        self.assertEqual(jewcal.events.yomtov, YOMTOV[7][19].title)  # Ch'H Sukkos 5
-
-        # Israel
-        jewcal = JewCal(gregorian_date, diaspora=False)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[6].title)  # Shabbos
-        self.assertEqual(jewcal.events.action, Action.HAVDALAH.value)
-        self.assertEqual(jewcal.events.yomtov, YOMTOV_ISRAEL[7][19].title)  # Sukkot 6
-
-    def test_shabbos_chol_hamoed_pesach(self) -> None:
-        """It is Shabbos Chol Hamoed Pesach with havdalah as action."""
-        gregorian_date = date(2020, 4, 11)
-
-        # Diaspora
-        jewcal = JewCal(gregorian_date)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[6].title)  # Shabbos
-        self.assertEqual(jewcal.events.action, Action.HAVDALAH.value)
-        self.assertEqual(jewcal.events.yomtov, YOMTOV[1][17].title)  # Ch'H Pesach 3
-
-        # Israel
-        jewcal = JewCal(gregorian_date, diaspora=False)
-
-        self.assertEqual(jewcal.jewish_date.gregorian_date, gregorian_date)
-
-        self.assertEqual(jewcal.events.shabbos, SHABBOS[6].title)  # Shabbos
-        self.assertEqual(jewcal.events.action, Action.HAVDALAH.value)
-        self.assertEqual(jewcal.events.yomtov, YOMTOV_ISRAEL[1][17].title)  # Pesach 3
-
     def test_jewcal_to_string(self) -> None:
         """Test `JewCal`-object to `str`."""
         # non-leap Jewish year
@@ -246,50 +112,6 @@ class JewCalTestCase(TestCase):
                 "action='Havdalah'), diaspora=False, zmanim=None)"
             ),
         )
-
-    def test_action_adjusted(self) -> None:
-        """Test adjusted action."""
-        # Diaspora
-        # 2023
-        erev_pesach = JewCal(date(2023, 4, 5))
-        self.assertEqual(erev_pesach.events.action, Action.CANDLES.value)
-
-        pesach_1 = JewCal(date(2023, 4, 6))
-        self.assertEqual(pesach_1.events.action, Action.CANDLES.value)
-
-        pesach_2 = JewCal(date(2023, 4, 7))
-        self.assertEqual(pesach_2.events.action, Action.CANDLES.value)
-
-        chol_hamoed_1 = JewCal(date(2023, 4, 8))
-        self.assertEqual(chol_hamoed_1.events.action, Action.HAVDALAH.value)
-
-        # 2024
-        chol_hamoed_2 = JewCal(date(2024, 4, 26))
-        self.assertEqual(chol_hamoed_2.events.action, Action.CANDLES.value)
-
-        chol_hamoed_3 = JewCal(date(2024, 4, 27))
-        self.assertEqual(chol_hamoed_3.events.action, Action.HAVDALAH.value)
-
-        # Israel
-        # 2023
-        erev_pesach = JewCal(date(2023, 4, 5), diaspora=False)
-        self.assertEqual(erev_pesach.events.action, Action.CANDLES.value)
-
-        pesach_1 = JewCal(date(2023, 4, 6), diaspora=False)
-        self.assertEqual(pesach_1.events.action, Action.HAVDALAH.value)
-
-        chol_hamoed_1 = JewCal(date(2023, 4, 7), diaspora=False)
-        self.assertEqual(chol_hamoed_1.events.action, Action.CANDLES.value)
-
-        chol_hamoed_2 = JewCal(date(2023, 4, 8), diaspora=False)
-        self.assertEqual(chol_hamoed_2.events.action, Action.HAVDALAH.value)
-
-        # 2024
-        chol_hamoed_3 = JewCal(date(2024, 4, 26))
-        self.assertEqual(chol_hamoed_3.events.action, Action.CANDLES.value)
-
-        chol_hamoed_4 = JewCal(date(2024, 4, 27))
-        self.assertEqual(chol_hamoed_4.events.action, Action.HAVDALAH.value)
 
     def test_deprecated_jewish_date_attributes(self) -> None:
         """Test deprecated jewish date attributes."""


### PR DESCRIPTION
Set shabbos and Yom Tov through the Events constructor instead of in the JewCal class.