### PR TITLE
refactor(sun): Use Astral for sunset/sunrise

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,35 +5,12 @@
 cd && git clone # path-to-this-repository.git
 ```
 
-### Python
-Verify if Python is installed.
+### uv
 ```sh
-python --version
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-To install multiple Python versions, use [pyenv](https://github.com/pyenv/pyenv).
-
-To activate:
-```sh
-pyenv local 3.10 3.11 3.12
-```
-
-### Virtual environment
-```sh
-cd # path-to-downloaded-repository
-python -m venv .env
-source .env/bin/activate
-```
-
-### pip and setuptools
-```sh
-python -m pip install --upgrade pip setuptools
-```
-
-### Dependencies
-```sh
-pip install -e .[dev]
-```
+https://docs.astral.sh/uv/getting-started/installation/
 
 ### Pre-commit
 ```sh
@@ -48,16 +25,16 @@ See [tox](pyproject.toml) for all test environments.
 
 To run all:
 ```sh
-tox
+uvx tox
 ```
 
 To run a specific environment:
 ```sh
-tox -e py311
+uvx tox -e py311
 ```
 
 To generate documentation:
 ```sh
-tox -e docs
+uvx tox -e docs
 ```
 The HTML pages are in docs/build/html.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ classifiers = [
   'Topic :: Utilities',
   'Typing :: Typed',
 ]
-dependencies = []
+dependencies = [
+    "astral>=3.2",
+]
 description = 'Convert Gregorian to Jewish dates with holidays and zmanim (Diaspora/Israel).'
 dynamic = ['version']
 keywords = [

--- a/src/jewcal/__init__.py
+++ b/src/jewcal/__init__.py
@@ -32,10 +32,10 @@ modules[__name__] = cast(ModuleType, _Wrapper(modules[__name__]))
 
 
 __all__ = [
+    'Events',
     'JewCal',
     'JewishDate',
-    'Month',
-    'Events',
     'Location',
+    'Month',
     'Zmanim',
 ]

--- a/src/jewcal/__main__.py
+++ b/src/jewcal/__main__.py
@@ -4,6 +4,7 @@ This script can be invoked from the command line:
     `jewcal`
 """
 
+from datetime import date
 from pprint import pprint
 
 from jewcal import JewCal
@@ -29,12 +30,26 @@ def main() -> None:
     location = Location(
         latitude=31.76904,
         longitude=35.21633,
-        use_tzeis_hakochavim=True,
+        use_tzeis_hakochavim=False,
         hadlokas_haneiros_minutes=40,
         tzeis_minutes=72,
     )
 
     jewcal = JewCal(diaspora=False, location=location)
+    if jewcal.zmanim:
+        pprint(jewcal.zmanim.to_dict())
+
+    print(f'\n{location}')
+
+    print('\n\nZmanim for Antwerp:')
+    location = Location(
+        latitude=51.201000,
+        longitude=4.421800,
+        use_tzeis_hakochavim=True,
+        hadlokas_haneiros_minutes=18,
+    )
+
+    jewcal = JewCal(diaspora=True, location=location, gregorian_date=date(2024, 12, 21))
     if jewcal.zmanim:
         pprint(jewcal.zmanim.to_dict())
 

--- a/src/jewcal/core.py
+++ b/src/jewcal/core.py
@@ -5,6 +5,8 @@ Diaspora
 
 >>> from jewcal import JewCal
 
+>>> from pprint import pprint
+
 >>> today = JewCal()  # today's date
 >>> pesach_2 = JewCal(date(2022, 4, 17))  # specific date
 
@@ -81,13 +83,13 @@ False
 >>> print(chol_hamoed_1.is_issur_melacha())
 False
 
->>> print(chol_hamoed_1.zmanim.to_dict())
-{'sunrise': '2022-04-17T03:06:33.211979+00:00',
-'sunset': '2022-04-17T16:08:57.179850+00:00',
-'plag_hamincha': '2022-04-17T14:47:27.183201+00:00',
-'hadlokas_haneiros': None,
-'tzeis_hakochavim': '2022-04-17T16:46:57.179850+00:00',
-'tzeis_minutes': '2022-04-17T17:20:57.179850+00:00'}
+>>> pprint(chol_hamoed_1.zmanim.to_dict())
+ {'hadlokas_haneiros': None,
+     'plag_hamincha': '2022-04-17T14:47:52.245352+00:00',
+     'sunrise': '2022-04-17T03:08:46.392244+00:00',
+     'sunset': '2022-04-17T16:09:09.670131+00:00',
+     'tzeis_hakochavim': '2022-04-17T16:47:02.815607+00:00',
+     'tzeis_minutes': '2022-04-17T17:21:09.670131+00:00'}
 """
 
 from datetime import date, timedelta

--- a/src/jewcal/helpers/sun.py
+++ b/src/jewcal/helpers/sun.py
@@ -1,20 +1,11 @@
-"""Derive the time for sun positions (USNO algorithm).
-
-Based on the source code from Ulrich and David Greve (2005)
-https://www.david-greve.de/luach-code/jewish-python.html
-"""
+"""Get sunrise, sunset using `Astral` library."""
 
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime
 from enum import Enum, unique
-from math import acos, atan, cos, degrees, fabs, floor, pi, sin, sqrt, tan
-from typing import Final
 
-ZENITH_DEG_HORIZON: Final[float] = 90
-ZENITH_MIN_HORIZON: Final[float] = 50
-HOUR_ANGLE: Final[float] = 15
-RAD_DEG: Final[float] = 180 / pi
-ROTATION_DEG = 360  # Sun is one revolution per day, that is 360° every 24 hours
+from astral import LocationInfo, Observer, SunDirection
+from astral.sun import sun, time_at_elevation
 
 
 @unique
@@ -25,22 +16,6 @@ class SunEvent(Enum):
     SET = 'sunset'
 
 
-class SunEventError(Exception):
-    """Sun exceptions."""
-
-    def __init__(
-        self,
-        message: str = f'Use {SunEvent.RISE.value} or {SunEvent.SET.value}.',
-    ) -> None:
-        """Initialize.
-
-        Args:
-            message: The error message.
-        """
-        self.message = message
-        super().__init__(self.message)
-
-
 @dataclass
 class Sun:
     """Sun positions for a geographic location on a certain date.
@@ -48,7 +23,6 @@ class Sun:
     Get the times in UTC for:
         - sunrise
         - sunset
-        - the sun at a certain degrees below horizon
     """
 
     date: date
@@ -72,394 +46,38 @@ class Sun:
     """The sea level in meters."""
 
     sunrise: datetime = field(init=False)
-    """The time for sunrise."""
+    """The time for sunrise in UTC."""
 
     sunset: datetime = field(init=False)
-    """The time for sunset."""
+    """The time for sunset in UTC."""
+
+    observer: Observer = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Set sunrise and sunset times."""
-        self.sunrise, self.sunset = self._sunrise_equation()
+        location = LocationInfo('', '', '', self.latitude, self.longitude)
+        self.observer = location.observer
+
+        s = sun(self.observer, date=self.date)
+
+        self.sunrise, self.sunset = s['sunrise'], s['sunset']
 
     def deg_below_horizon(
         self,
         deg_below_horizon: float,
         sun_event: SunEvent,
     ) -> datetime:
-        """Get the time for the sun at a certain degrees below horizon.
+        """Get the time for the sun at a certain degrees above / below horizon.
 
         Args:
-            deg_below_horizon: The degrees below horizon.
+            deg_below_horizon: The degrees above / below horizon.
             sun_event: The sun event (sunrise or sunset).
-
-        Returns:
-            The time.
-        """
-        zenith_adjusted = deg_below_horizon + ZENITH_DEG_HORIZON
-        zenith_deg = floor(zenith_adjusted)
-        zenith_min = floor((zenith_adjusted - zenith_deg) * 60)
-        sunset_below = self._sunrise_equation(zenith_deg, zenith_min)[1]
-
-        sunset_minutes = self.sunset.hour * 60 + self.sunset.minute
-        sunset_below_minutes = sunset_below.hour * 60 + sunset_below.minute
-
-        delta_minutes = sunset_below_minutes - sunset_minutes
-
-        match sun_event:
-            case SunEvent.RISE:
-                return self.sunrise - timedelta(minutes=delta_minutes)
-            case SunEvent.SET:
-                return self.sunset + timedelta(minutes=delta_minutes)
-
-    def _sunrise_equation(  # pylint: disable=too-many-locals
-        self,
-        zenith_deg: float = ZENITH_DEG_HORIZON,
-        zenith_min: float = ZENITH_MIN_HORIZON,
-    ) -> tuple[datetime, datetime]:
-        """Get the times for sunrise and sunset.
-
-        Sunrise and sunset occur when the zenith angle is at 90° 50'.
-
-        To get the times at a certain point below horizon, adjust:
-            - ``zenith_deg``.
-            - ``zenith_min``.
-
-        Args:
-            zenith_deg: The zenith position in degrees.
-            zenith_min: The zenith position in minutes.
-
-        Returns:
-            The times for sunrise and sunset.
-        """
-        # local hour angle
-        local_hour_angle = self._local_hour_angle()
-
-        # local apparent time
-        sunrise_local_apparent_time = self._local_apparent_time(
-            local_hour_angle,
-            SunEvent.RISE,
-        )
-        sunset_local_apparent_time = self._local_apparent_time(
-            local_hour_angle,
-            SunEvent.SET,
-        )
-
-        # local mean time
-        sunrise_local_mean_time = self._local_mean_time(sunrise_local_apparent_time)
-        sunset_local_mean_time = self._local_mean_time(sunset_local_apparent_time)
-
-        # mean anomaly
-        sunrise_mean_anomaly = self._mean_anomaly(sunrise_local_apparent_time)
-        sunset_mean_anomaly = self._mean_anomaly(sunset_local_apparent_time)
-
-        # true longitude
-        sunrise_true_longitude = self._true_longitude(sunrise_mean_anomaly)
-        sunset_true_longitude = self._true_longitude(sunset_mean_anomaly)
-
-        # declination
-        sun_declination = self._declination(
-            sunrise_true_longitude,
-            zenith_deg,
-            zenith_min,
-        )
-
-        # solar hour angle
-        sunrise_solar_hour_angle = self._solar_hour_angle(
-            sun_declination,
-            SunEvent.RISE,
-        )
-        sunset_solar_hour_angle = self._solar_hour_angle(
-            sun_declination,
-            SunEvent.SET,
-        )
-
-        # right ascension hour angle
-        sunrise_right_ascension_hour_angle = self._right_ascension_hour_angle(
-            sunrise_true_longitude,
-        )
-        sunset_right_ascension_hour_angle = self._right_ascension_hour_angle(
-            sunset_true_longitude,
-        )
-
-        # datetime
-        sunrise_utc = self.__utc_time(
-            sunrise_solar_hour_angle,
-            sunrise_right_ascension_hour_angle,
-            sunrise_local_mean_time,
-            local_hour_angle,
-        )
-        sunset_utc = self.__utc_time(
-            sunset_solar_hour_angle,
-            sunset_right_ascension_hour_angle,
-            sunset_local_mean_time,
-            local_hour_angle,
-        )
-
-        return sunrise_utc, sunset_utc
-
-    def _local_hour_angle(self) -> float:
-        """Get the local hour angle.
-
-        Returns:
-            The local hour angle.
-        """
-        longitude = float(self.longitude * 100)
-        longitude_deg, longitude_min = self.__dd_to_ddm(longitude)
-        longitude = self.__ddm_to_dd(longitude_deg, longitude_min)
-
-        if self.__is_east_of_meridian():
-            longitude *= -1
-
-        return longitude / HOUR_ANGLE
-
-    def _local_apparent_time(
-        self,
-        local_hour_angle: float,
-        sun_event: SunEvent,
-    ) -> float:
-        """Get the local apparent time for sunrise or sunset.
-
-        Args:
-            local_hour_angle: The local hour angle.
-            sun_event: The sun event (sunrise or sunset).
-
-        Returns:
-            The time.
-        """
-        day = self.date.timetuple().tm_yday + 1
-
-        match sun_event:
-            case SunEvent.RISE:
-                return day + (6 + local_hour_angle) / 24
-            case SunEvent.SET:
-                return day + (18 + local_hour_angle) / 24
-
-    def _local_mean_time(self, local_apparent_time: float) -> float:
-        """Get the local mean time.
-
-        Args:
-            local_apparent_time: The local apparent time.
-
-        Returns:
-            The local mean time.
-        """
-        return -0.06571 * local_apparent_time - 6.620
-
-    def _mean_anomaly(self, local_apparent_time: float) -> float:
-        """Get the mean anomaly.
-
-        Args:
-            local_apparent_time: The local apparent time.
-
-        Returns:
-            The mean anomaly.
-        """
-        return ROTATION_DEG / 365.25 * local_apparent_time - 3.251
-
-    def _true_longitude(self, mean_anomaly: float) -> float:
-        """Get the true longitude.
-
-        Args:
-            mean_anomaly: The mean anomaly.
-
-        Returns:
-            The true longitude.
-        """
-        return (
-            mean_anomaly
-            + 1.916 * sin(0.01745 * mean_anomaly)
-            + 0.02 * sin(2 * 0.01745 * mean_anomaly)
-            + 282.565
-        )
-
-    def _declination(  # pylint: disable=too-many-locals
-        self,
-        sunrise_true_longitude: float,
-        zenith_deg: float,
-        zenith_min: float,
-    ) -> float:
-        """Get the declination.
-
-        Args:
-            sunrise_true_longitude: The true longitude for sunrise.
-            zenith_deg: The zenith position in degrees.
-            zenith_min: The zenith position in minutes.
-
-        Returns:
-            The declination.
-
-        Raises:
-            SunEventError: If there is no sunrise/sunset at this location.
-        """
-        if zenith_deg == ZENITH_DEG_HORIZON:
-            earth_radius_meters = 6356.9 * 1000
-            elevation_adjusted = degrees(
-                acos(earth_radius_meters / (earth_radius_meters + self.elevation)),
-            )
-
-            zenith_adjusted = (
-                self.__ddm_to_dd(zenith_deg, zenith_min) + elevation_adjusted
-            )
-            zenith_deg = floor(zenith_adjusted)
-            zenith_min = (zenith_adjusted - floor(zenith_adjusted)) * 60
-        zenith_cos = cos(0.01745 * self.__ddm_to_dd(zenith_deg, zenith_min))
-
-        declination_sin = 0.39782 * sin(0.01745 * sunrise_true_longitude)
-        declination_cos = sqrt(1 - declination_sin * declination_sin)
-
-        latitude_deg, latitude_min = self.__dd_to_ddm(float(self.latitude * 100))
-        latitude = self.__ddm_to_dd(latitude_deg, latitude_min)
-        if not self.__is_above_equator():
-            latitude *= -1
-        latitude_cos = cos(0.01745 * latitude)
-        latitude_sin = sin(0.01745 * latitude)
-
-        declination = (zenith_cos - declination_sin * latitude_sin) / (
-            declination_cos * latitude_cos
-        )
-        if abs(declination) <= 1:
-            return RAD_DEG * acos(declination)
-        error = 'No sunrise/sunset at this location'
-        raise SunEventError(error)
-
-    def _solar_hour_angle(
-        self,
-        sunrise_declination: float,
-        sun_event: SunEvent,
-    ) -> float:
-        """Get the solar hour angle.
-
-        Args:
-            sunrise_declination: The declination at sunrise.
-            sun_event: The sun event (sunrise or sunset).
-
-        Returns:
-            The solar hour angle.
-        """
-        match sun_event:
-            case SunEvent.RISE:
-                return ROTATION_DEG - sunrise_declination / HOUR_ANGLE
-            case SunEvent.SET:
-                return sunrise_declination / HOUR_ANGLE
-
-    def _right_ascension_hour_angle(self, true_longitude: float) -> float:
-        """Get the right ascension hour angle.
-
-        Args:
-            true_longitude: The true longitude.
-
-        Returns:
-            The right ascension hour angle.
-        """
-        # right ascension
-        right_ascension = RAD_DEG * atan(0.91746 * tan(0.01745 * true_longitude))
-
-        # right ascension value must be in same quadrant as true_longitude
-        if abs(right_ascension + ROTATION_DEG - true_longitude) > ZENITH_DEG_HORIZON:
-            right_ascension += 180.0
-        if right_ascension > ROTATION_DEG:
-            right_ascension -= ROTATION_DEG
-
-        # right ascension to hour angle
-        return right_ascension / HOUR_ANGLE
-
-    def __utc_time(
-        self,
-        solar_hour_angle: float,
-        right_ascension_hour_angle: float,
-        local_mean_time: float,
-        local_hour_angle: float,
-    ) -> datetime:
-        """Get the time in UTC.
-
-        Args:
-            solar_hour_angle: The solar hour angle.
-            right_ascension_hour_angle: The right ascension hour angle.
-            local_mean_time:  The local mean time.
-            local_hour_angle: The local hour angle.
 
         Returns:
             The time in UTC.
         """
-        utc = (
-            solar_hour_angle
-            + right_ascension_hour_angle
-            + local_mean_time
-            + local_hour_angle
+        direction: SunDirection = (
+            SunDirection.RISING if sun_event is SunEvent.RISE else SunDirection.SETTING
         )
 
-        if utc < 0:
-            utc += 24
-
-        time_of_day = utc % 24
-
-        hours, rest = divmod(time_of_day * 3600, 3600)
-        minutes, rest = divmod(rest, 60)
-        seconds, microseconds = divmod(rest * 10**6, 10**6)
-
-        return datetime(
-            self.date.year,
-            self.date.month,
-            self.date.day,
-            int(hours),
-            int(minutes),
-            int(seconds),
-            int(microseconds),
-            tzinfo=timezone.utc,
-        )
-
-    def __is_above_equator(self) -> bool:
-        """Is the latitude above the equator.
-
-        Positive latitudes are North, negative latitudes are South.
-
-        Returns:
-            True if above the equator, False otherwise.
-        """
-        return bool(self.latitude >= 0)
-
-    def __is_east_of_meridian(self) -> bool:
-        """Is the longitude east of the meridian.
-
-        Positive longitudes are East, negative longitudes are West.
-
-        Returns:
-            True if east of the meridian, False otherwise.
-        """
-        return bool(self.longitude >= 0)
-
-    def __ddm_to_dd(self, deg: float, dec_min: float) -> float:
-        """Convert degrees and decimal minutes (DDM) to decimal degrees (DD).
-
-        Example:
-            - Decimal degrees (DD): 41.40338, 2.17403
-            - Degrees, minutes, and seconds (DMS): 41°24'12.2"N 2°10'26.5"E
-            - Degrees and decimal minutes (DDM): 41 24.2028, 2 10.4418
-
-        Args:
-            deg: The degrees.
-            dec_min: The decimal minutes.
-
-        Returns:
-            The decimal degrees.
-        """
-        return deg + dec_min / 60
-
-    def __dd_to_ddm(self, dec_deg: float) -> tuple[float, float]:
-        """Convert decimal degrees (DD) to degrees and decimal minutes (DDM).
-
-        Example:
-            - Decimal degrees (DD): 41.40338, 2.17403
-            - Degrees, minutes, and seconds (DMS): 41°24'12.2"N 2°10'26.5"E
-            - Degrees and decimal minutes (DDM): 41 24.2028, 2 10.4418
-
-        Args:
-            dec_deg: The decimal degrees.
-
-        Returns:
-            The degrees and decimal minutes.
-        """
-        deg = float(floor(fabs(dec_deg / 100)))
-        dec_min = abs(dec_deg) % 100
-
-        return deg, dec_min
+        return time_at_elevation(self.observer, deg_below_horizon, self.date, direction)

--- a/src/jewcal/models/zmanim.py
+++ b/src/jewcal/models/zmanim.py
@@ -9,7 +9,7 @@ from jewcal.utils.datetime import date_today, datetime_now
 
 HALACHIC_HOURS: Final[int] = 12
 PLAG_HAMINCHA: Final[float] = 10.75
-TZEIS_HAKOCHAVIM: Final[float] = 8.5
+TZEIS_HAKOCHAVIM: Final[float] = -8.5
 
 
 @dataclass
@@ -25,7 +25,7 @@ class Location:
     use_tzeis_hakochavim: bool = field(default=True)
     """Use Tzeis Hakochavim or Tzeis at minutes after sunset for nightfall.
 
-    `True` to use :py:class:`Zmanim.hadlokas_haneiros`, `False` to use
+    `True` to use :py:class:`Zmanim.tzeis_hakochavim`, `False` to use
     :py:class:`Zmanim.tzeis_minutes`.
     """
 

--- a/tests/jewcal/helpers/test_sun.py
+++ b/tests/jewcal/helpers/test_sun.py
@@ -1,4 +1,4 @@
-"""Unittests for jewcal.helpers.sun."""
+"""Unit tests for jewcal.helpers.sun."""
 
 from datetime import date, datetime, timezone
 from unittest import TestCase
@@ -7,14 +7,14 @@ from src.jewcal.helpers.sun import Sun, SunEvent
 
 
 class SunTestCase(TestCase):
-    """Unittests for sun."""
+    """Unit tests for sun."""
 
     def test_init(self) -> None:
         """Test init."""
         lat, lon = 51.22047, 4.40026
 
-        expected_sunrise = datetime(2024, 5, 31, 3, 29, 55, 470753, tzinfo=timezone.utc)
-        expected_sunset = datetime(2024, 5, 31, 19, 47, 51, 641803, tzinfo=timezone.utc)
+        expected_sunrise = datetime(2024, 5, 31, 3, 33, 11, 506283, tzinfo=timezone.utc)
+        expected_sunset = datetime(2024, 5, 31, 19, 47, 48, 504226, tzinfo=timezone.utc)
 
         sun = Sun(date(2024, 5, 31), lat, lon)
 
@@ -27,10 +27,10 @@ class SunTestCase(TestCase):
             2024,
             6,
             1,
-            20,
-            59,
-            55,
-            50901,
+            18,
+            39,
+            42,
+            429379,
             tzinfo=timezone.utc,
         )
 

--- a/tests/jewcal/models/test_zmanim.py
+++ b/tests/jewcal/models/test_zmanim.py
@@ -1,4 +1,4 @@
-"""Unittests for jewcal.models.zmanim."""
+"""Unit tests for jewcal.models.zmanim."""
 
 from datetime import date, datetime, timezone
 from unittest import TestCase
@@ -8,7 +8,7 @@ from src.jewcal.models.zmanim import Location, Zmanim
 
 
 class ZmanimTestCase(TestCase):
-    """Unittests for Zmanim."""
+    """Unit tests for Zmanim."""
 
     def test_to_dict(self) -> None:
         """Test to_dict."""
@@ -33,20 +33,29 @@ class ZmanimTestCase(TestCase):
         Raises:
             TypeError: If Zmanim is `None`
         """
-        # Antwerpen
+        # Antwerp
         lat, lon = 51.22047, 4.40026
         location = Location(latitude=lat, longitude=lon)
 
         # erev shabbos
-        expected_plag = datetime(2024, 5, 31, 18, 5, 59, 540654, tzinfo=timezone.utc)
-        expected_neiros = datetime(2024, 5, 31, 19, 29, 51, 641803, tzinfo=timezone.utc)
+        expected_plag = datetime(2024, 5, 31, 18, 6, 17, 150275, tzinfo=timezone.utc)
+        expected_neiros = datetime(2024, 5, 31, 19, 29, 48, 504226, tzinfo=timezone.utc)
         erev_shabbos = Zmanim(date(2024, 5, 31), location, set_hadlokas_haneiros=True)
         self.assertEqual(expected_plag, erev_shabbos.plag_hamincha)
         self.assertEqual(expected_neiros, erev_shabbos.hadlokas_haneiros)
 
         # motse shabbos
-        expected_kochavim = datetime(2024, 6, 1, 20, 59, 55, 50901, tzinfo=timezone.utc)
-        expected_minutes = datetime(2024, 6, 1, 21, 0, 55, 50901, tzinfo=timezone.utc)
+        expected_kochavim = datetime(
+            2024,
+            6,
+            1,
+            20,
+            59,
+            43,
+            842312,
+            tzinfo=timezone.utc,
+        )
+        expected_minutes = datetime(2024, 6, 1, 21, 0, 52, 414259, tzinfo=timezone.utc)
         shabbos = Zmanim(date(2024, 6, 1), location)
         self.assertEqual(expected_kochavim, shabbos.tzeis_hakochavim)
         self.assertEqual(expected_minutes, shabbos.tzeis_minutes)
@@ -61,8 +70,8 @@ class ZmanimTestCase(TestCase):
         )
 
         # erev shabbos
-        expected_plag = datetime(2024, 6, 21, 15, 19, 6, 523393, tzinfo=timezone.utc)
-        expected_neiros = datetime(2024, 6, 21, 16, 8, 16, 510134, tzinfo=timezone.utc)
+        expected_plag = datetime(2024, 6, 21, 15, 18, 44, 74017, tzinfo=timezone.utc)
+        expected_neiros = datetime(2024, 6, 21, 16, 7, 36, 170118, tzinfo=timezone.utc)
         erev_shabbos = Zmanim(date(2024, 6, 21), location, set_hadlokas_haneiros=True)
         self.assertEqual(expected_plag, erev_shabbos.plag_hamincha)
         self.assertEqual(expected_neiros, erev_shabbos.hadlokas_haneiros)
@@ -73,12 +82,21 @@ class ZmanimTestCase(TestCase):
             6,
             22,
             17,
+            30,
             31,
-            26,
-            984992,
+            678394,
             tzinfo=timezone.utc,
         )
-        expected_minutes = datetime(2024, 6, 22, 18, 0, 26, 984992, tzinfo=timezone.utc)
+        expected_minutes = datetime(
+            2024,
+            6,
+            22,
+            17,
+            59,
+            47,
+            450800,
+            tzinfo=timezone.utc,
+        )
         shabbos = Zmanim(date(2024, 6, 22), location)
         self.assertEqual(expected_kochavim, shabbos.tzeis_hakochavim)
         self.assertEqual(expected_minutes, shabbos.tzeis_minutes)
@@ -91,7 +109,7 @@ class ZmanimTestCase(TestCase):
         mock_now: Mock,
     ) -> None:
         """Test now is after nightfall."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         location = Location(latitude=lat, longitude=lon)
 
         mock_today.return_value = date(2024, 5, 31)
@@ -111,7 +129,7 @@ class ZmanimTestCase(TestCase):
         mock_now: Mock,
     ) -> None:
         """Test now is not after nightfall."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         location = Location(latitude=lat, longitude=lon)
 
         mock_today.return_value = date(2024, 5, 31)

--- a/tests/jewcal/test_core.py
+++ b/tests/jewcal/test_core.py
@@ -1,4 +1,4 @@
-"""Unittests for jewcal.core."""
+"""Unit tests for jewcal.core."""
 
 from datetime import date, datetime, timezone
 from doctest import NORMALIZE_WHITESPACE, DocTestSuite
@@ -14,7 +14,7 @@ from src.jewcal.models.zmanim import Location
 @no_type_check
 # pylint: disable=unused-argument
 def load_tests(loader, tests, ignore):  # noqa: ANN201, ANN001, ARG001
-    """Run the doctests in jewcal.core for documentation (tutorials).
+    """Run the doc tests in jewcal.core for documentation (tutorials).
 
     # noqa: DAR101 loader
     # noqa: DAR101 tests
@@ -26,7 +26,7 @@ def load_tests(loader, tests, ignore):  # noqa: ANN201, ANN001, ARG001
 
 
 class JewCalTestCase(TestCase):
-    """Unittests for JewCal."""
+    """Unit tests for JewCal."""
 
     def setUp(self) -> None:
         """Initialize."""
@@ -165,7 +165,7 @@ class JewCalTestCase(TestCase):
 
     def test_zmanim_init(self) -> None:
         """Test Zmanim init."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         jewcal = JewCal(location=Location(latitude=lat, longitude=lon))
         self.assertIsNotNone(jewcal.zmanim)
 
@@ -182,7 +182,7 @@ class JewCalTestCase(TestCase):
         mock_today: Mock,
     ) -> None:
         """Test Gregorian date should be next day."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         location = Location(latitude=lat, longitude=lon)
 
         date_ = date(2024, 5, 31)
@@ -199,7 +199,7 @@ class JewCalTestCase(TestCase):
         mock_today: Mock,
     ) -> None:
         """Test Gregorian date remains the same."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         location = Location(latitude=lat, longitude=lon)
 
         date_ = date(2024, 5, 31)
@@ -210,7 +210,7 @@ class JewCalTestCase(TestCase):
 
     def test_hadlokas_haneiros_is_set(self) -> None:
         """Test Hadlokas Haneiros is set."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         location = Location(latitude=lat, longitude=lon)
 
         date_ = date(2024, 5, 31)  # erev shabbos
@@ -229,11 +229,11 @@ class JewCalTestCase(TestCase):
         mock_now: Mock,
     ) -> None:
         """Test has Hadlokas Haneiros, is after nightfall, has next Gregorian date."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         location = Location(latitude=lat, longitude=lon)
 
-        date_ = date(2024, 7, 25)
-        now_ = datetime(2024, 7, 25, 20, 42, tzinfo=timezone.utc)
+        date_ = date(2024, 7, 25)  # Thursday
+        now_ = datetime(2024, 7, 25, 23, 42, tzinfo=timezone.utc)  # after nightfall
         mock_core_today.return_value = date_
         mock_today.return_value = date_
         mock_now.return_value = now_
@@ -245,7 +245,7 @@ class JewCalTestCase(TestCase):
 
     def test_hadlokas_haneiros_is_set_second_day_yom_tov(self) -> None:
         """Test has Hadlokas Haneiros for second day of Yom Tov."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         location = Location(latitude=lat, longitude=lon)
 
         date_ = date(2024, 6, 11)  # Erev Shavuos
@@ -280,7 +280,7 @@ class JewCalTestCase(TestCase):
 
     def test_hadlokas_haneiros_is_not_set(self) -> None:
         """Test Hadlokas Haneiros is not set."""
-        lat, lon = 51.22047, 4.40026  # Antwerpen
+        lat, lon = 51.22047, 4.40026  # Antwerp
         location = Location(latitude=lat, longitude=lon)
 
         date_ = date(2024, 6, 1)  # shabbos


### PR DESCRIPTION
This commit replaces the previous custom sunset and sunrise calculation logic with the `astral` package.

The `astral` package provides a more robust and accurate method for calculating these times, taking into account factors such as elevation and atmospheric refraction.

This change improves the overall accuracy of zmanim calculations, particularly for locations with significant elevation or unusual atmospheric conditions.

The following updates were made:

- Removed custom sunset and sunrise calculation functions.
- Installed the `astral` package.
- Updated `zmanim` calculations to use `astral`'s API for determining sunrise and sunset.
- Updated unit tests to reflect the new calculation method.