### PR TITLE
feat: Add support for Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -22,16 +22,17 @@ repos:
     ]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.9
+  rev: v0.8.4
   hooks:
     - id: ruff
     - id: ruff-format
 
 - repo: https://github.com/PyCQA/pylint
-  rev: v3.2.3
+  rev: v3.3.2
   hooks:
     - id: pylint
       pass_filenames: false
+      additional_dependencies: [astral]
       args: [
         'src',
         'tests',
@@ -39,6 +40,7 @@ repos:
       ]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.0
+  rev: v1.13.0
   hooks:
   - id: mypy
+    additional_dependencies: [astral]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
   'Topic :: Utilities',
   'Typing :: Typed',
 ]
@@ -56,7 +57,7 @@ dev = [
 legacy_tox_ini = """
 	[tox]
 	envlist =
-		py{310,311,312}
+		py{310,311,312,313}
         ruff-format
 		ruff-lint
 		pylint
@@ -74,7 +75,7 @@ legacy_tox_ini = """
 		py310: coverage[toml]
 	commands =
 		coverage run -m unittest discover
-		py312: coverage report -m
+		py313: coverage report -m
 
 	[testenv:pylint]
 	deps = pylint
@@ -116,7 +117,8 @@ legacy_tox_ini = """
 	python =
 		3.10: py310
 		3.11: py311
-		3.12: py312, isort, ruff-format, ruff-lint, pylint, mypy, darglint, jewcal
+		3.12: py312
+		3.13: py313, isort, ruff-format, ruff-lint, pylint, mypy, darglint, jewcal
 """
 
 [tool.coverage.run]


### PR DESCRIPTION
This commit adds support for Python 3.13 to the project.

To ensure compatibility with Python 3.13, testing for this version has been added to the CI pipeline.

This enhancement ensures that the project remains up-to-date and compatible with the latest versions of Python.