### PR TITLE
refactor(sun): Remove unused elevation attribute

### DIFF
--- a/src/jewcal/helpers/sun.py
+++ b/src/jewcal/helpers/sun.py
@@ -42,9 +42,6 @@ class Sun:
         - Decimal degrees (DD): 2.17403
     """
 
-    elevation: float = 0
-    """The sea level in meters."""
-
     sunrise: datetime = field(init=False)
     """The time for sunrise in UTC."""
 


### PR DESCRIPTION
The `elevation` attribute in `DataClass` was unused and has been removed to improve code clarity.